### PR TITLE
Avaliações de Serviços (CRUD) + fixes de validação

### DIFF
--- a/src/main/java/com/servifacil/SF_BackEnd/controllers/AssessmentController.java
+++ b/src/main/java/com/servifacil/SF_BackEnd/controllers/AssessmentController.java
@@ -1,0 +1,97 @@
+package com.servifacil.SF_BackEnd.controllers;
+
+import com.servifacil.SF_BackEnd.dto.AssessmentCreateRequest;
+import com.servifacil.SF_BackEnd.dto.AssessmentResponse;
+import com.servifacil.SF_BackEnd.dto.AssessmentUpdateRequest;
+import com.servifacil.SF_BackEnd.services.AssessmentService;
+import jakarta.validation.Valid;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/assessments")
+public class AssessmentController {
+
+    private final AssessmentService assessmentService;
+
+    public AssessmentController(AssessmentService assessmentService) {
+        this.assessmentService = assessmentService;
+    }
+
+    @PostMapping
+    public ResponseEntity<?> criar(@Valid @RequestBody AssessmentCreateRequest request) {
+        try {
+            AssessmentResponse resp = assessmentService.criar(request);
+            return ResponseEntity.status(HttpStatus.CREATED).body(resp);
+        } catch (IllegalArgumentException e) {
+            return ResponseEntity.badRequest().body(new ErrorResponse("Dados inválidos: " + e.getMessage()));
+        } catch (RuntimeException e) {
+            return ResponseEntity.badRequest().body(new ErrorResponse(e.getMessage()));
+        } catch (Exception e) {
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                    .body(new ErrorResponse("Erro interno no servidor"));
+        }
+    }
+
+    @GetMapping("/servico/{serviceId}")
+    public ResponseEntity<?> listarPorServico(@PathVariable int serviceId) {
+        try {
+            List<AssessmentResponse> list = assessmentService.listarPorServico(serviceId);
+            return ResponseEntity.ok(list);
+        } catch (IllegalArgumentException e) {
+            return ResponseEntity.badRequest().body(new ErrorResponse("Dados inválidos: " + e.getMessage()));
+        } catch (RuntimeException e) {
+            return ResponseEntity.badRequest().body(new ErrorResponse(e.getMessage()));
+        } catch (Exception e) {
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                    .body(new ErrorResponse("Erro interno no servidor"));
+        }
+    }
+
+    @PutMapping("/{id}")
+    public ResponseEntity<?> editar(@PathVariable("id") int id,
+                                    @Valid @RequestBody AssessmentUpdateRequest request) {
+        try {
+            AssessmentResponse resp = assessmentService.editar(id, request);
+            return ResponseEntity.ok(resp);
+        } catch (IllegalArgumentException e) {
+            return ResponseEntity.badRequest().body(new ErrorResponse("Dados inválidos: " + e.getMessage()));
+        } catch (RuntimeException e) {
+            return ResponseEntity.badRequest().body(new ErrorResponse(e.getMessage()));
+        } catch (Exception e) {
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                    .body(new ErrorResponse("Erro interno no servidor"));
+        }
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<?> excluir(@PathVariable("id") int id) {
+        try {
+            assessmentService.excluir(id);
+            return ResponseEntity.noContent().build();
+        } catch (IllegalArgumentException e) {
+            return ResponseEntity.badRequest().body(new ErrorResponse("Dados inválidos: " + e.getMessage()));
+        } catch (RuntimeException e) {
+            return ResponseEntity.badRequest().body(new ErrorResponse(e.getMessage()));
+        } catch (Exception e) {
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                    .body(new ErrorResponse("Erro interno no servidor"));
+        }
+    }
+
+    public static class ErrorResponse {
+        private String message;
+        private long timestamp;
+
+        public ErrorResponse(String message) {
+            this.message = message;
+            this.timestamp = System.currentTimeMillis();
+        }
+
+        public String getMessage() { return message; }
+        public long getTimestamp() { return timestamp; }
+    }
+}

--- a/src/main/java/com/servifacil/SF_BackEnd/controllers/ServiceController.java
+++ b/src/main/java/com/servifacil/SF_BackEnd/controllers/ServiceController.java
@@ -2,6 +2,8 @@ package com.servifacil.SF_BackEnd.controllers;
 
 import com.servifacil.SF_BackEnd.models.ServiceModel;
 import com.servifacil.SF_BackEnd.services.ServiceService;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -17,32 +19,33 @@ public class ServiceController {
     }
 
     @PostMapping("/criar")
-    public ServiceModel criar(@RequestBody ServiceModel service) {
-        return service.criarServico(service);
+    public ResponseEntity<ServiceModel> criar(@RequestBody ServiceModel payload) {
+        ServiceModel criado = this.service.criarServico(payload);
+        return ResponseEntity.status(HttpStatus.CREATED).body(criado);
     }
 
     @GetMapping("/listar")
     public List<ServiceModel> listar() {
-        return service.listarServicos();
+        return this.service.listarServicos();
     }
 
     @GetMapping("/buscar/nome/{nome}")
-    public List<ServiceModel> buscarPorNome(@PathVariable String name) {
-        return service.buscarPorNome(name);
+    public List<ServiceModel> buscarPorNome(@PathVariable("nome") String nome) {
+        return this.service.buscarPorNome(nome);
     }
 
     @GetMapping("/buscar/categoria/{id}")
-    public List<ServiceModel> buscarPorCategoria(@PathVariable int id) {
-        return service.buscarPorCategoria(id);
+    public List<ServiceModel> buscarPorCategoria(@PathVariable("id") int id) {
+        return this.service.buscarPorCategoria(id);
     }
 
     @PutMapping("/editar/{id}")
-    public ServiceModel editar(@PathVariable int id, @RequestBody ServiceModel service) {
-        return service.editarServico(id, service);
+    public ServiceModel editar(@PathVariable("id") int id, @RequestBody ServiceModel payload) {
+        return this.service.editarServico(id, payload);
     }
 
     @DeleteMapping("/excluir/{id}")
-    public void excluir(@PathVariable int id) {
-        service.excluirServico(id);
+    public void excluir(@PathVariable("id") int id) {
+        this.service.excluirServico(id);
     }
 }

--- a/src/main/java/com/servifacil/SF_BackEnd/controllers/ServiceController.java
+++ b/src/main/java/com/servifacil/SF_BackEnd/controllers/ServiceController.java
@@ -17,8 +17,8 @@ public class ServiceController {
     }
 
     @PostMapping("/criar")
-    public ServiceModel criar(@RequestBody ServiceModel servico) {
-        return service.criarServico(servico);
+    public ServiceModel criar(@RequestBody ServiceModel service) {
+        return service.criarServico(service);
     }
 
     @GetMapping("/listar")
@@ -27,8 +27,8 @@ public class ServiceController {
     }
 
     @GetMapping("/buscar/nome/{nome}")
-    public List<ServiceModel> buscarPorNome(@PathVariable String nome) {
-        return service.buscarPorNome(nome);
+    public List<ServiceModel> buscarPorNome(@PathVariable String name) {
+        return service.buscarPorNome(name);
     }
 
     @GetMapping("/buscar/categoria/{id}")
@@ -37,8 +37,8 @@ public class ServiceController {
     }
 
     @PutMapping("/editar/{id}")
-    public ServiceModel editar(@PathVariable int id, @RequestBody ServiceModel servico) {
-        return service.editarServico(id, servico);
+    public ServiceModel editar(@PathVariable int id, @RequestBody ServiceModel service) {
+        return service.editarServico(id, service);
     }
 
     @DeleteMapping("/excluir/{id}")

--- a/src/main/java/com/servifacil/SF_BackEnd/controllers/ServiceController.java
+++ b/src/main/java/com/servifacil/SF_BackEnd/controllers/ServiceController.java
@@ -1,0 +1,48 @@
+package com.servifacil.SF_BackEnd.controllers;
+
+import com.servifacil.SF_BackEnd.models.ServiceModel;
+import com.servifacil.SF_BackEnd.services.ServiceService;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/servicos")
+public class ServiceController {
+
+    private final ServiceService service;
+
+    public ServiceController(ServiceService service) {
+        this.service = service;
+    }
+
+    @PostMapping("/criar")
+    public ServiceModel criar(@RequestBody ServiceModel servico) {
+        return service.criarServico(servico);
+    }
+
+    @GetMapping("/listar")
+    public List<ServiceModel> listar() {
+        return service.listarServicos();
+    }
+
+    @GetMapping("/buscar/nome/{nome}")
+    public List<ServiceModel> buscarPorNome(@PathVariable String nome) {
+        return service.buscarPorNome(nome);
+    }
+
+    @GetMapping("/buscar/categoria/{id}")
+    public List<ServiceModel> buscarPorCategoria(@PathVariable int id) {
+        return service.buscarPorCategoria(id);
+    }
+
+    @PutMapping("/editar/{id}")
+    public ServiceModel editar(@PathVariable int id, @RequestBody ServiceModel servico) {
+        return service.editarServico(id, servico);
+    }
+
+    @DeleteMapping("/excluir/{id}")
+    public void excluir(@PathVariable int id) {
+        service.excluirServico(id);
+    }
+}

--- a/src/main/java/com/servifacil/SF_BackEnd/dto/AssessmentCreateRequest.java
+++ b/src/main/java/com/servifacil/SF_BackEnd/dto/AssessmentCreateRequest.java
@@ -1,0 +1,36 @@
+package com.servifacil.SF_BackEnd.dto;
+
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.Positive;
+import jakarta.validation.constraints.Size;
+
+public class AssessmentCreateRequest {
+
+    @Positive(message = "serviceId deve ser > 0")
+    private int serviceId;
+
+    @Positive(message = "clientId deve ser > 0")
+    private int clientId;
+
+    @Min(value = 1, message = "Score deve ser entre 1 e 5")
+    @Max(value = 5, message = "Score deve ser entre 1 e 5")
+    private int score;
+
+    @Size(max = 500, message ="Comentário deve ter no máximo 500 caracteres")
+    private String comment;
+
+    public AssessmentCreateRequest(){}
+
+    public int getServiceId() { return serviceId; }
+    public void setServiceId(int serviceId) { this.serviceId = serviceId; }
+
+    public int getClientId() { return clientId; }
+    public void setClientId(int clientId) { this.clientId = clientId; }
+
+    public int getScore() { return score; }
+    public void setScore(int score) { this.score = score; }
+
+    public String getComment() { return comment; }
+    public void setComment(String comment) { this.comment = comment; }
+}

--- a/src/main/java/com/servifacil/SF_BackEnd/dto/AssessmentResponse.java
+++ b/src/main/java/com/servifacil/SF_BackEnd/dto/AssessmentResponse.java
@@ -1,0 +1,32 @@
+package com.servifacil.SF_BackEnd.dto;
+
+public class AssessmentResponse {
+
+    private int assessmentId;
+    private int serviceId;
+    private int clientId;
+    private int score;
+    private String comment;
+
+    public AssessmentResponse(){}
+
+    public AssessmentResponse(int assessmentId, int serviceId, int clientId, int score, String comment) {
+        this.assessmentId = assessmentId;
+        this.serviceId = serviceId;
+        this.clientId = clientId;
+        this.score = score;
+        this.comment = comment;
+    }
+
+    public int getAssessmentId() { return assessmentId; }
+    public int getServiceId() { return serviceId; }
+    public int getClientId() { return clientId; }
+    public int getScore() { return score; }
+    public String getComment() { return comment; }
+
+    public void setAssessmentId(int assessmentId) { this.assessmentId = assessmentId; }
+    public void setServiceId(int serviceId) { this.serviceId = serviceId; }
+    public void setClientId(int clientId) { this.clientId = clientId; }
+    public void setScore(int score) { this.score = score; }
+    public void setComment(String comment) { this.comment = comment; }
+}

--- a/src/main/java/com/servifacil/SF_BackEnd/dto/AssessmentUpdateRequest.java
+++ b/src/main/java/com/servifacil/SF_BackEnd/dto/AssessmentUpdateRequest.java
@@ -1,0 +1,22 @@
+package com.servifacil.SF_BackEnd.dto;
+
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.Size;
+
+public class AssessmentUpdateRequest {
+    @Min(value = 1, message = "score deve ser entre 1 e 5")
+    @Max(value = 5, message = "score deve ser entre 1 e 5")
+    private Integer score;
+
+    @Size(max = 500, message = "Comentário deve ter no máximo 500 caracteres")
+    private String comment;
+
+    public AssessmentUpdateRequest(){}
+
+    public Integer getScore() { return score; }
+    public void setScore(Integer score) { this.score = score; }
+
+    public String getComment() { return comment; }
+    public void setComment(String comment) { this.comment = comment; }
+}

--- a/src/main/java/com/servifacil/SF_BackEnd/models/AssessmentModel.java
+++ b/src/main/java/com/servifacil/SF_BackEnd/models/AssessmentModel.java
@@ -1,6 +1,8 @@
 package com.servifacil.SF_BackEnd.models;
 
 import jakarta.persistence.*;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
 
 @Entity
@@ -19,7 +21,8 @@ public class AssessmentModel {
     private int clientId;
 
     @Column(name = "Score")
-    @NotBlank
+    @Min(value = 1, message = "Score deve ser no mínimo 1")
+    @Max(value = 5, message = "Score deve ser no máximo 5")
     private int score;
 
     @Column(name = "Comments")

--- a/src/main/java/com/servifacil/SF_BackEnd/models/ServiceModel.java
+++ b/src/main/java/com/servifacil/SF_BackEnd/models/ServiceModel.java
@@ -1,7 +1,10 @@
 package com.servifacil.SF_BackEnd.models;
 
 import jakarta.persistence.*;
+import jakarta.validation.constraints.DecimalMin;
+import jakarta.validation.constraints.Digits;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Positive;
 
 @Entity
 @Table(name = "tbServices")
@@ -17,7 +20,7 @@ public class ServiceModel {
     private String title;
 
     @Column(name = "Price")
-    @NotBlank
+    @Positive(message = "Preço deve ser maior que 0")
     private double price;
 
     @Column(name = "Details")

--- a/src/main/java/com/servifacil/SF_BackEnd/repositories/AssessmentRepository.java
+++ b/src/main/java/com/servifacil/SF_BackEnd/repositories/AssessmentRepository.java
@@ -1,0 +1,14 @@
+package com.servifacil.SF_BackEnd.repositories;
+
+import com.servifacil.SF_BackEnd.models.AssessmentModel;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface AssessmentRepository extends JpaRepository<AssessmentModel, Integer> {
+    List<AssessmentModel> findByServiceId(int serviceId);
+    List<AssessmentModel> findByClientId(int clientId);
+    boolean existsByServiceIdAndClientId(int serviceId, int clientId); //evita duplicidade
+}

--- a/src/main/java/com/servifacil/SF_BackEnd/repositories/ServiceRepository.java
+++ b/src/main/java/com/servifacil/SF_BackEnd/repositories/ServiceRepository.java
@@ -1,0 +1,11 @@
+package com.servifacil.SF_BackEnd.repositories;
+
+import com.servifacil.SF_BackEnd.models.ServiceModel;
+import org.springframework.data.jpa.repository.JpaRepository;
+import java.util.List;
+
+public interface ServiceRepository extends JpaRepository<ServiceModel, Integer> {
+    List<ServiceModel> findByTitleContainingIgnoreCase(String title);
+    List<ServiceModel> findByCategoryId(int categoryId);
+    List<ServiceModel> findByProfessionalId(int professionalId);
+}

--- a/src/main/java/com/servifacil/SF_BackEnd/services/AssessmentService.java
+++ b/src/main/java/com/servifacil/SF_BackEnd/services/AssessmentService.java
@@ -1,0 +1,96 @@
+package com.servifacil.SF_BackEnd.services;
+
+import com.servifacil.SF_BackEnd.dto.AssessmentCreateRequest;
+import com.servifacil.SF_BackEnd.dto.AssessmentResponse;
+import com.servifacil.SF_BackEnd.dto.AssessmentUpdateRequest;
+import com.servifacil.SF_BackEnd.models.AssessmentModel;
+import com.servifacil.SF_BackEnd.models.ServiceModel;
+import com.servifacil.SF_BackEnd.repositories.AssessmentRepository;
+import com.servifacil.SF_BackEnd.repositories.ServiceRepository;
+import com.servifacil.SF_BackEnd.repositories.UserRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+public class AssessmentService {
+
+    private final AssessmentRepository assessmentRepository;
+    private final ServiceRepository serviceRepository; // vem da PR
+    private final UserRepository userRepository;
+
+    public AssessmentService(AssessmentRepository assessmentRepository,
+                             ServiceRepository serviceRepository,
+                             UserRepository userRepository) {
+        this.assessmentRepository = assessmentRepository;
+        this.serviceRepository = serviceRepository;
+        this.userRepository = userRepository;
+    }
+
+    @Transactional
+    public AssessmentResponse criar(AssessmentCreateRequest req) {
+        // 1) valida usuário (cliente) existe
+        if (!userRepository.existsById(req.getClientId())) {
+            throw new IllegalArgumentException("Cliente não encontrado");
+        }
+
+        // 2) valida serviço existe e está ATIVO
+        ServiceModel service = serviceRepository.findById(req.getServiceId())
+                .orElseThrow(() -> new IllegalArgumentException("Serviço não encontrado"));
+
+        boolean ativo = "ACTIVE".equalsIgnoreCase(String.valueOf(service.getServiceStatus()));
+        if (!ativo) {
+            throw new IllegalArgumentException("Serviço indisponível para avaliação");
+        }
+
+        AssessmentModel entity = new AssessmentModel();
+        entity.setServiceId(req.getServiceId());
+        entity.setClientId(req.getClientId());
+        entity.setScore(req.getScore());
+        entity.setComment(req.getComment());
+
+        AssessmentModel saved = assessmentRepository.save(entity);
+        return toResponse(saved);
+    }
+
+    @Transactional(readOnly = true)
+    public List<AssessmentResponse> listarPorServico(int serviceId) {
+        // garante que o serviço existe (mesmo se INATIVO, você ainda pode querer listar avaliações)
+        serviceRepository.findById(serviceId)
+                .orElseThrow(() -> new IllegalArgumentException("Serviço não encontrado"));
+        return assessmentRepository.findByServiceId(serviceId).stream()
+                .map(this::toResponse)
+                .toList();
+    }
+
+    @Transactional
+    public AssessmentResponse editar(int assessmentId, AssessmentUpdateRequest req) {
+        AssessmentModel entity = assessmentRepository.findById(assessmentId)
+                .orElseThrow(() -> new IllegalArgumentException("Avaliação não encontrada"));
+
+        if (req.getScore() != null) entity.setScore(req.getScore());
+        if (req.getComment() != null) entity.setComment(req.getComment());
+
+        AssessmentModel saved = assessmentRepository.save(entity);
+        return toResponse(saved);
+    }
+
+    @Transactional
+    public void excluir(int assessmentId) {
+        if (!assessmentRepository.existsById(assessmentId)) {
+            throw new IllegalArgumentException("Avaliação não encontrada");
+        }
+        assessmentRepository.deleteById(assessmentId);
+    }
+
+    private AssessmentResponse toResponse(AssessmentModel a) {
+        return new AssessmentResponse(
+                a.getAssessmentId(),
+                a.getServiceId(),
+                a.getClientId(),
+                a.getScore(),
+                a.getComment()
+        );
+    }
+}

--- a/src/main/java/com/servifacil/SF_BackEnd/services/ServiceService.java
+++ b/src/main/java/com/servifacil/SF_BackEnd/services/ServiceService.java
@@ -15,20 +15,20 @@ public class ServiceService {
         this.repository = repository;
     }
 
-    public ServiceModel criarServico(ServiceModel servico) {
-        return repository.save(servico);
+    public ServiceModel criarServico(ServiceModel service) {
+        return repository.save(service);
     }
 
     public List<ServiceModel> listarServicos() {
         return repository.findAll();
     }
 
-    public List<ServiceModel> buscarPorNome(String nome) {
-        return repository.findByTitleContainingIgnoreCase(nome);
+    public List<ServiceModel> buscarPorNome(String name) {
+        return repository.findByTitleContainingIgnoreCase(name);
     }
 
-    public List<ServiceModel> buscarPorCategoria(int categoriaId) {
-        return repository.findByCategoryId(categoriaId);
+    public List<ServiceModel> buscarPorCategoria(int categoryId) {
+        return repository.findByCategoryId(categoryId);
     }
 
     public List<ServiceModel> buscarPorProfissional(int profissionalId) {

--- a/src/main/java/com/servifacil/SF_BackEnd/services/ServiceService.java
+++ b/src/main/java/com/servifacil/SF_BackEnd/services/ServiceService.java
@@ -1,0 +1,50 @@
+package com.servifacil.SF_BackEnd.services;
+
+import com.servifacil.SF_BackEnd.models.ServiceModel;
+import com.servifacil.SF_BackEnd.repositories.ServiceRepository;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+public class ServiceService {
+
+    private final ServiceRepository repository;
+
+    public ServiceService(ServiceRepository repository) {
+        this.repository = repository;
+    }
+
+    public ServiceModel criarServico(ServiceModel servico) {
+        return repository.save(servico);
+    }
+
+    public List<ServiceModel> listarServicos() {
+        return repository.findAll();
+    }
+
+    public List<ServiceModel> buscarPorNome(String nome) {
+        return repository.findByTitleContainingIgnoreCase(nome);
+    }
+
+    public List<ServiceModel> buscarPorCategoria(int categoriaId) {
+        return repository.findByCategoryId(categoriaId);
+    }
+
+    public List<ServiceModel> buscarPorProfissional(int profissionalId) {
+        return repository.findByProfessionalId(profissionalId);
+    }
+
+    public ServiceModel editarServico(int id, ServiceModel novoServico) {
+        ServiceModel servico = repository.findById(id).orElseThrow();
+        servico.setTitle(novoServico.getTitle());
+        servico.setPrice(novoServico.getPrice());
+        servico.setDetails(novoServico.getDetails());
+        servico.setCategoryId(novoServico.getCategoryId());
+        return repository.save(servico);
+    }
+
+    public void excluirServico(int id) {
+        repository.deleteById(id);
+    }
+}


### PR DESCRIPTION
### Resumo
Implementa CRUD de **Avaliações** e corrige validações que causavam erro 500.

> **Depende da PR #1.**
> Esta PR está empilhada sobre as mudanças da #1. Assim que a #1 for mergeada, farei **rebase** para manter apenas os meus commits.

### Mudanças
- **Assessment**
  - Novos DTOs: `AssessmentCreateRequest`, `AssessmentUpdateRequest`, `AssessmentResponse`
  - `AssessmentRepository`, `AssessmentService`, `AssessmentController`
  - Endpoints:
    - `POST /api/assessments` (criar)
    - `GET /api/assessments/servico/{serviceId}` (listar por serviço)
    - `PUT /api/assessments/{id}` (editar)
    - `DELETE /api/assessments/{id}` (excluir)
  - Regra: só permite avaliar **serviço ACTIVE**; valida serviço e cliente existentes.
  - `AssessmentModel`: `score` com `@Min(1)` e `@Max(5)` (remove `@NotBlank` em `int`).

- **Serviços**
  - `ServiceController`: corrige shadowing de parâmetro e `@PathVariable`; `criar` retorna 201.
  - `ServiceModel`: `price` validado com `@Positive` (remove anotação incompatível com `double`).

### Como testar (Postman)
1. **Criar PROFISSIONAL**: `POST /api/users`  
   - Observação: `zipCode` **sem hífen** (ex.: `01001000`) por causa da `spInsertAddress`.
2. **Criar SERVIÇO (ACTIVE)**: `POST /servicos/criar`
3. **Criar CLIENTE**: `POST /api/users`
4. **Criar AVALIAÇÃO**: `POST /api/assessments`
5. **Listar AVALIAÇÕES**: `GET /api/assessments/servico/{serviceId}`
6. **Editar**: `PUT /api/assessments/{assessmentId}`
7. **Excluir**: `DELETE /api/assessments/{assessmentId}`

### Casos de erro cobertos
- Serviço inexistente → 400
- Serviço **INACTIVE** → 400 (“Serviço indisponível para avaliação”)
- `score` fora de 1..5 → 400 (validação)
- CEP com hífen → erro de truncamento na procedure (documentado)

### Notas
- `SecurityConfig` permanece com `permitAll` para facilitar testes locais.
- Sem mudanças de credenciais ou propriedades sensíveis.